### PR TITLE
chore: bump actions/checkout from v1 to v2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ jobs:
   textlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: textlint
         uses: tsuyoshicho/action-textlint@v1
         with:


### PR DESCRIPTION
Fetch performance has been improved since `v2.0.0`.
https://github.com/actions/checkout/releases/tag/v2.0.0