### PR TITLE
Add lint rule about spacing

### DIFF
--- a/.textlintrc.js
+++ b/.textlintrc.js
@@ -24,6 +24,10 @@ module.exports = {
     "ja-technical-writing/max-comma": false, // 翻訳完了後に有効化
     "textlint-rule-ja-hiragana-hojodoushi": true, // ひらがなにしたほうが良い補助動詞
     "textlint-rule-ja-hiragana-fukushi": true, // ひらがなにしたほうが良い副詞
+    "ja-space-between-half-and-full-width": {
+      space: "always",
+      exceptPunctuation: true,
+    }, // 半角文字と全角文字の切替時にスペースを入れる
   },
   filters: {
     // https://github.com/textlint/textlint-filter-rule-comments

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "textlint-rule-ja-hiragana-fukushi": "^1.2.0",
     "textlint-rule-ja-hiragana-hojodoushi": "^1.0.4",
     "textlint-rule-ja-hiragana-keishikimeishi": "^1.0.2",
+    "textlint-rule-preset-ja-spacing": "^2.0.1",
     "textlint-rule-preset-ja-technical-writing": "^3.1.3",
     "textlint-rule-preset-jtf-style": "^2.3.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2713,6 +2713,14 @@ textlint-rule-ja-hiragana-keishikimeishi@^1.0.2:
     kuromojin "^1.3.2"
     morpheme-match-all "^1.1.0"
 
+textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana/-/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana-2.0.1.tgz#ea6f94cb9ced758fb2553dea2e9fe714f31f0aed"
+  integrity sha1-6m+Uy5ztdY+yVT3qLp/nFPMfCu0=
+  dependencies:
+    match-index "^1.0.1"
+    textlint-rule-helper "^2.0.0"
+
 textlint-rule-ja-no-abusage@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/textlint-rule-ja-no-abusage/-/textlint-rule-ja-no-abusage-1.2.2.tgz#6478a150d4dcea4e95bb88a2af92a2fcace1c5f0"
@@ -2739,6 +2747,23 @@ textlint-rule-ja-no-redundant-expression@^2.0.0:
     morpheme-match "^1.0.1"
     morpheme-match-all "^1.1.0"
 
+textlint-rule-ja-no-space-around-parentheses@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/textlint-rule-ja-no-space-around-parentheses/-/textlint-rule-ja-no-space-around-parentheses-2.0.1.tgz#556a60e679da9b4c98244c67e7961ac2e540bec1"
+  integrity sha1-VWpg5nnam0yYJExn55YawuVAvsE=
+  dependencies:
+    match-index "^1.0.1"
+    textlint-rule-helper "^2.0.0"
+
+textlint-rule-ja-no-space-between-full-width@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/textlint-rule-ja-no-space-between-full-width/-/textlint-rule-ja-no-space-between-full-width-2.0.1.tgz#921f78561564dd00c8733c230254acd8a55ded67"
+  integrity sha1-kh94VhVk3QDIczwjAlSs2KVd7Wc=
+  dependencies:
+    match-index "^1.0.1"
+    regx "^1.0.4"
+    textlint-rule-helper "^2.0.0"
+
 textlint-rule-ja-no-successive-word@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/textlint-rule-ja-no-successive-word/-/textlint-rule-ja-no-successive-word-1.1.0.tgz#243778076ce3f80d76bf2b9b73156c161e33c998"
@@ -2754,6 +2779,38 @@ textlint-rule-ja-no-weak-phrase@^1.0.2:
     kuromojin "^1.3.1"
     morpheme-match "^1.0.1"
     morpheme-match-all "^1.1.0"
+
+textlint-rule-ja-space-after-exclamation@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/textlint-rule-ja-space-after-exclamation/-/textlint-rule-ja-space-after-exclamation-2.0.1.tgz#3bc5d48c13269bd9cb1b18eb82e3d4eae44dfba3"
+  integrity sha1-O8XUjBMmm9nLGxjrguPU6uRN+6M=
+  dependencies:
+    match-index "^1.0.1"
+    textlint-rule-helper "^2.0.0"
+
+textlint-rule-ja-space-after-question@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/textlint-rule-ja-space-after-question/-/textlint-rule-ja-space-after-question-2.0.1.tgz#122260cb97d203768820276b4d09bf5270b11dfa"
+  integrity sha1-EiJgy5fSA3aIICdrTQm/UnCxHfo=
+  dependencies:
+    match-index "^1.0.1"
+    textlint-rule-helper "^2.0.0"
+
+textlint-rule-ja-space-around-code@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/textlint-rule-ja-space-around-code/-/textlint-rule-ja-space-around-code-2.0.1.tgz#6b7011dab69488f1eddd445554e7cddeaf1a90d3"
+  integrity sha1-a3AR2raUiPHt3URVVOfN3q8akNM=
+  dependencies:
+    match-index "^1.0.1"
+    textlint-rule-helper "^2.0.0"
+
+textlint-rule-ja-space-between-half-and-full-width@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/textlint-rule-ja-space-between-half-and-full-width/-/textlint-rule-ja-space-between-half-and-full-width-2.0.1.tgz#a527f83bd833149763e4043965f796c9ec2192ba"
+  integrity sha1-pSf4O9gzFJdj5AQ5ZfeWyewhkro=
+  dependencies:
+    match-index "^1.0.1"
+    textlint-rule-helper "^2.0.0"
 
 textlint-rule-max-comma@^1.0.2:
   version "1.0.4"
@@ -2859,6 +2916,19 @@ textlint-rule-no-nfd@^1.0.1:
     match-index "^1.0.3"
     textlint-rule-helper "^2.1.1"
     unorm "^1.4.1"
+
+textlint-rule-preset-ja-spacing@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/textlint-rule-preset-ja-spacing/-/textlint-rule-preset-ja-spacing-2.0.1.tgz#4426e812b2fd525ed4c39d07ede2984ee9bf89d9"
+  integrity sha1-RCboErL9Ul7Uw50H7eKYTum/idk=
+  dependencies:
+    textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana "^2.0.1"
+    textlint-rule-ja-no-space-around-parentheses "^2.0.1"
+    textlint-rule-ja-no-space-between-full-width "^2.0.1"
+    textlint-rule-ja-space-after-exclamation "^2.0.1"
+    textlint-rule-ja-space-after-question "^2.0.1"
+    textlint-rule-ja-space-around-code "^2.0.1"
+    textlint-rule-ja-space-between-half-and-full-width "^2.0.1"
 
 textlint-rule-preset-ja-technical-writing@^3.1.3:
   version "3.1.3"


### PR DESCRIPTION
全角文字と半角文字の間にスペースを入れるための textlint rule を追加しました。
例外として、句読点の周りにはスペース付けなくて良いようになっています。