### PR TITLE
chore(ci): fix textlint CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: textlint
-        run: $(yarn bin)/textlint -f checkstyle ${FILES} | reviewdog -f=checkstyle -name="textlint" -reporter=github-pr-check -level=${LEVEL}
+        run: $(yarn bin)/textlint -f checkstyle ${FILES} | reviewdog -f=checkstyle -name="textlint" -reporter=github-pr-review -level=${LEVEL}
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILES: README.md docs/**/*.md


### PR DESCRIPTION
WHY: github-pr-check won't put the result on Check UI since the bot has no permission to post them in a forked repo.