### PR TITLE
Translate docs/v1-release-notes.md

### DIFF
--- a/docs/docs/v1-release-notes.md
+++ b/docs/docs/v1-release-notes.md
@@ -1,9 +1,9 @@
 ---
-title: v1 Release Notes
+title: v1 リリースノート
 ---
 
-Check out the following useful links for Gatsby version 1:
+以下の Gatsby バージョン 1 の便利なリンクをご覧ください。
 
-- [v1 documentation](https://v1.gatsbyjs.org/)
-- [v1 changelog](https://github.com/gatsbyjs/gatsby/blob/master/CHANGELOG.md#100---2017-07-06)
-- [v1 release announcement](/blog/gatsby-v1/)
+- [v1 ドキュメント](https://v1.gatsbyjs.org/)
+- [v1 変更履歴](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/CHANGELOG.md#100---2017-07-06)
+- [v1 リリース告知](/blog/gatsby-v1/)


### PR DESCRIPTION
Translated to Japanese and fixed the link to `CHANGELOG.md`.

About the change of the link, the original document is needed to change also, so I made https://github.com/gatsbyjs/gatsby/pull/20644 for it.