### PR TITLE
docs: translate docs/recipes/working-with-starters

### DIFF
--- a/docs/docs/recipes/working-with-starters.md
+++ b/docs/docs/recipes/working-with-starters.md
@@ -1,37 +1,37 @@
 ---
-title: "Recipes: Working with Starters"
+title: "レシピ: スターターを使用する"
 ---
 
-[Starters](/docs/starters/) are boilerplate Gatsby sites maintained officially, or by the community.
+[スターター](/docs/starters/) は、公式もしくはコミュニティーによって整備された Gatsby サイトのボイラープレートです。
 
-## Using a starter
+## スターターを使用する
 
-### Prerequisites
+### 前提条件
 
-- The [Gatsby CLI](/docs/gatsby-cli) installed
+- [Gatsby CLI](/docs/gatsby-cli) がインストールされていること。
 
-### Directions
+### 使い方
 
-1. Find the starter you'd like to use. (_The [Starter Library](/starters/?v=2) is a good place to look!_)
+1. あなたの使いたいスターターを探してください。 (_[Starter Library](/starters/?v=2) を見てみると良いでしょう!_)
 
-2. Generate a new site based on the starter. In the terminal, run:
+2. そのスターターをベースにして、新しいサイトを作成します。ターミナルで、次のコマンドを流してください。
 
 ```shell
 gatsby new {your-project-name} {link-to-starter}
 ```
 
-> _Don't run the above command as-is -- remember to replace {your-project-name} and {link-to-starter}!_
+> _上記のコマンドをそのまま流さないでください。 -- {your-project-name} と {link-to-starter} を置き換えるのを忘れないでください!_
 
-3. Run your new site:
+3. 新しく作られたサイトを起動します。
 
 ```shell
 cd {your-project-name}
 gatsby develop
 ```
 
-### Additional resources
+### 追加資料
 
-- Follow a [more detailed guide](/docs/starters/) on using Gatsby starters.
-- Learn how to use the [Gatsby CLI](/docs/gatsby-cli) tool to use starters in [tutorial part one](/tutorial/part-one/#using-gatsby-starters)
-- Browse the [Starter Library](/starters/?v=2)
-- Check out Gatsby's [official default starter](https://github.com/gatsbyjs/gatsby-starter-default)
+- Gatsby スターターの使い方は、 [more detailed guide](/docs/starters/) をご覧ください。
+- [tutorial part one](/tutorial/part-one/#using-gatsby-starters) を読むことで、スターターを使うために必要な [Gatsby CLI](/docs/gatsby-cli) ツールの使い方を学ぶことができます。
+- [Starter Library](/starters/?v=2) をざっと見てみましょう。
+- Gatsby の [official default starter](https://github.com/gatsbyjs/gatsby-starter-default) も一度ご覧ください。

--- a/docs/docs/recipes/working-with-starters.md
+++ b/docs/docs/recipes/working-with-starters.md
@@ -20,7 +20,7 @@ title: "レシピ: スターターを使用する"
 gatsby new {your-project-name} {link-to-starter}
 ```
 
-> _上記のコマンドをそのまま流さないでください。 -- {your-project-name} と {link-to-starter} を置き換えるのを忘れないでください!_
+> _上記のコマンドをそのまま実行しないでください。 -- {your-project-name} と {link-to-starter} を置き換えるのを忘れないでください!_
 
 3. 新しく作られたサイトを起動します。
 


### PR DESCRIPTION
I translated docs/recipes/working-with-starters into Japanese.
Original page: [docs/recipes/working-with-starters](https://www.gatsbyjs.org/docs/recipes/working-with-starters/)

レビューよろしくお願い致します🙇