### PR TITLE
Translation docs/running-queries-with-graphiql into Japanese

### DIFF
--- a/docs/docs/running-queries-with-graphiql.md
+++ b/docs/docs/running-queries-with-graphiql.md
@@ -1,48 +1,48 @@
 ---
-title: Introducing GraphiQL
+title: GraphiQLの紹介
 ---
 
-In this guide, you'll be learning to use something called GraphiQL, a tool that helps you structure GraphQL queries correctly.
+このガイドでは、正しい構成の GraphiQL クエリーを作ることができる GraphiQL というツールの使用方法を学習します。
 
-## What is GraphiQL?
+## GraphiQL とは？
 
-GraphiQL is the GraphQL integrated development environment (IDE). It's a powerful (and all-around awesome) tool
-you'll use often while building Gatsby websites.
+GraphiQL は、GraphQL の統合開発環境（IDE）です。GraphiQL は強力な（そして万能な）ツールです。
+Gatsby サイトを構築する際に、頻繁に使用することになるでしょう。
 
-You can access it when your site's development server is running--normally at
+開発環境のサーバーを実行中に、GraphiQL へアクセスできます。
+通常、以下の URL になります。
 <http://localhost:8000/___graphql>.
 
-## Example of using GraphiQL
+## GraphiQL の使用例
 
-When you have <http://localhost:8000/___graphql> open, it will look something like what this video shows. In the video below, watch someone poke around the built-in `Site` "type" and see what fields are available
-on it—including the `siteMetadata` object.
+<http://localhost:8000/___graphql>を開くと、以下の動画のように表示されます。ビルドインの `Site` "type" を突っつくと、`siteMetadata`オブジェクトを含んだ、どのフィールドを利用できるかを確認することができます。
 
 <video controls="controls" autoplay="true" loop="true">
   <source type="video/mp4" src="/graphiql-explore.mp4" />
-  <p>Your browser does not support the video element.</p>
+  <p>お使いのブラウザは、video要素をサポートしていません。</p>
 </video>
 
-## How to use GraphiQL
+## GraphiQL の使用方法
 
-When the development server is running for one of your Gatsby sites, open GraphiQL at <http://localhost:8000/___graphql> and play with your data! Press <kbd>Ctrl + Space</kbd> (or use <kbd>Shift + Space</kbd> as an alternate keyboard shortcut) to bring up the autocomplete window and <kbd>Ctrl + Enter</kbd> to run the GraphQL query.
+Gatsby サイトで開発環境のサーバーを実行中に、<http://localhost:8000/___graphql>で GraphiQL を開き、データを操作します！ <kbd> Ctrl +Space</kbd>を押して（または<kbd> Shift + Space</kbd>を別のショートカットに登録し使用して）オートコンプリートウィンドウを表示し、<kbd> Ctrl + Enter </kbd>で GraphQL クエリーを実行します。
 
-Make sure to check out the GraphiQL docs in the upper right-hand corner of the IDE. It's easy to miss them, but they're worth visiting!
+IDE の右上の端にある GraphiQL のドキュメントを読んでみてください。スルーしてしまいがちですが、読んで見る価値はあります！
 
-![A diagram pointing out where to find the GraphiQl docs](./images/graphiql-docs.png)
+![GraphiQlドキュメントの場所を示す図](./images/graphiql-docs.png)
 
-## Using the GraphiQL Explorer
+## GraphiQL Explorer の使用
 
-The GraphiQL Explorer enables you to interactively construct full queries by clicking through available fields and inputs without the repetitive process of typing these queries out by hand.
+GraphiQL Explorer を使用すれば、使用可能なフィールドと入力をクリックすることで、クエリーを手作業で何度も入力することなく、相互補完的にクエリーを完成させることができます。
 
 <EggheadEmbed
   lessonLink="https://egghead.io/lessons/gatsby-build-a-graphql-query-using-gatsby-s-graphiql-explorer"
-  lessonTitle="Build a GraphQL Query using Gatsby’s GraphiQL Explorer"
+  lessonTitle="Build a GraphQL Query using Gatsbyâ€™s GraphiQL Explorer"
 />
 
-Read more [about the GraphiQL Explorer](/blog/2019-06-03-integrating-graphiql-explorer/) on the Gatsby blog.
+GraphiQL Explorer についてもっと知りたい場合は、Gatsby ブログの[GraphiQL Explorer についての記事](/blog/2019-06-03-integrating-graphiql-explorer/)をご覧ください。
 
-## Other resources
+## その他のリソース
 
-- See [Tutorial Part 5: Source Plugins](/tutorial/part-five/) for a more complete example of using GraphiQL
-- See the [README for GraphiQL](https://github.com/graphql/graphiql)
-- See [Using GraphQL Playground](/docs/using-graphql-playground/) for another example of a GraphQL IDE
+- GraphiQL の使用例については [Tutorial Part 5: Source Plugins](/tutorial/part-five/) をご覧ください。
+- [GraphiQL の README](https://github.com/graphql/graphiql)をご覧ください。
+- GraphQL IDE の他の使用例については、[Using GraphQL Playground](/docs/using-graphql-playground/)をご覧ください。

--- a/docs/docs/running-queries-with-graphiql.md
+++ b/docs/docs/running-queries-with-graphiql.md
@@ -2,7 +2,7 @@
 title: GraphiQLの紹介
 ---
 
-このガイドでは、正しい構成の GraphiQL クエリーを作ることができる GraphiQL というツールの使用方法を学習します。
+このガイドでは、正しい構成の GraphQL クエリーを作ることができる GraphiQL というツールの使用方法を学習します。
 
 ## GraphiQL とは？
 

--- a/docs/docs/running-queries-with-graphiql.md
+++ b/docs/docs/running-queries-with-graphiql.md
@@ -36,7 +36,7 @@ GraphiQL Explorer を使用すれば、使用可能なフィールドと入力�
 
 <EggheadEmbed
   lessonLink="https://egghead.io/lessons/gatsby-build-a-graphql-query-using-gatsby-s-graphiql-explorer"
-  lessonTitle="Build a GraphQL Query using Gatsbyâ€™s GraphiQL Explorer"
+  lessonTitle="Build a GraphQL Query using Gatsby's GraphiQL Explorer"
 />
 
 GraphiQL Explorer についてもっと知りたい場合は、Gatsby ブログの[GraphiQL Explorer についての記事](/blog/2019-06-03-integrating-graphiql-explorer/)をご覧ください。


### PR DESCRIPTION
## 概要

#1 の対応として、 `docs/running-queries-with-graphiql ` を翻訳しました。

原文ページ：https://www.gatsbyjs.org/docs/running-queries-with-graphiql/

## チェックリスト

- [x] [翻訳スタイルガイド](https://github.com/gatsbyjs/gatsby-ja/blob/master/style-guide.md) に目を通しました。
- [x] [Translation Guide](https://www.gatsbyjs.org/contributing/gatsby-docs-translation-guide/#contributing-to-a-translation) に目を通しました。
- [x] `textlint` を使って校正を行いました（推奨）
- [x] `Allow edits from maintainers` にチェックを入れました。

しばらく待ってもレビューが終わらなかったり、必要なレビュー数が足りない状態が続いた場合は、[こちら](https://github.com/gatsbyjs/gatsby-ja/issues/1)からメンテナーを探して、@を付けてメンションを飛ばしてください。