### PR TITLE
Fix markdown of tutorial/part-one

### DIFF
--- a/docs/tutorial/part-one/index.md
+++ b/docs/tutorial/part-one/index.md
@@ -169,7 +169,7 @@ export default () => (
 
 ![新しい about ページ](05-about-page.png)
 
-React コンポーネントを 'src/pages/about.js`ファイルに配置するだけで、`/about` でアクセス可能なページを作成します。
+React コンポーネントを `src/pages/about.js` ファイルに配置するだけで、`/about` でアクセス可能なページを作成します。
 
 ### ✋ サブコンポーネントの使用
 

--- a/docs/tutorial/part-one/index.md
+++ b/docs/tutorial/part-one/index.md
@@ -8,7 +8,7 @@ disableTableOfContents: true
 
 ## Gatsby スターターの使用
 
-[**チュートリアル・パート 0**](/tutorial/part-zero/)で、次のコマンドを使用して"hello world""スターターに基づいて新しいサイトを作成しました。
+[**チュートリアル・パート 0**](/tutorial/part-zero/)で、次のコマンドを使用して"hello world"スターターに基づいて新しいサイトを作成しました。
 
 ```shell
 gatsby new hello-world https://github.com/gatsbyjs/gatsby-starter-hello-world


### PR DESCRIPTION
## 概要

`tutorial/part-one` のマークダウン及びテキストを修正しました。

## チェックリスト

- [x] [翻訳スタイルガイド](https://github.com/gatsbyjs/gatsby-ja/blob/master/style-guide.md) に目を通しました。
- [x] [Translation Guide](https://www.gatsbyjs.org/contributing/gatsby-docs-translation-guide/#contributing-to-a-translation) に目を通しました。
- [x] `textlint` を使って校正を行いました。
- [x] 文章全体を最初から読み直して不自然な箇所が無いことを確認しました。
- [x] `Allow edits from maintainers` にチェックを入れました。

> しばらく待ってもレビューが終わらなかったり、必要なレビュー数に足りない状態が続いた場合は、[こちら](https://github.com/gatsbyjs/gatsby-ja/issues/1)からメンテナーを探して、@を付けてメンションを飛ばしてください。

## 補足

<!-- 必要であればこちらに補足を書いてください -->

<!-- ここから下は消さないで！ -->

Ref: #1
