### PR TITLE
Translate docs/add-page-metadata

### DIFF
--- a/docs/docs/add-page-metadata.md
+++ b/docs/docs/add-page-metadata.md
@@ -1,24 +1,24 @@
 ---
-title: Adding Page Metadata
+title: ページのメタデータを追加する
 ---
 
-If you've run an [audit with Lighthouse](/docs/audit-with-lighthouse/), you may have noticed a lackluster score in the "SEO" category. Let's address how you can improve that score.
+[Lighthouse による評価](/docs/audit-with-lighthouse/) を実施したときに、SEO カテゴリのスコアが良くないことに気づいたかもしれません。ここではスコアを上げる方法について紹介します。
 
-Adding metadata to pages (such as a title or description) is key in helping search engines like Google understand your content, and decide when to surface it in search results.
+ページにメタデータ（タイトルや説明など）を追加することは、Google などの検索エンジンにコンテンツを理解させ、検索結果で上位表示をするために重要です。
 
-[React Helmet](https://github.com/nfl/react-helmet) is a package that provides a React component interface for you to manage your [document head](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head).
+[React Helmet](https://github.com/nfl/react-helmet) は、[ドキュメントヘッド](https://developer.mozilla.org/ja-JP/docs/Web/HTML/Element/head)を管理するための React コンポーネントインターフェイスを提供するパッケージです。
 
-Gatsby's [react helmet plugin](/packages/gatsby-plugin-react-helmet/) provides drop-in support for server rendering data added with React Helmet. Using the plugin, attributes you add to React Helmet will be added to the static HTML pages that Gatsby builds.
+Gatsby の [React Helmet プラグイン](/packages/gatsby-plugin-react-helmet/)は、React Helmet で追加されたサーバーレンダリングデータのドロップインサポートを提供します。プラグインを使用すると、React Helmet に追加した属性が Gatsby がビルドする静的 HTML ページに追加されます。
 
-## Using `React Helmet` and `gatsby-plugin-react-helmet`
+## `React Helmet` と `gatsby-plugin-react-helmet` を使用する
 
-1. Install both packages:
+1. 両方のパッケージをインストールします。
 
 ```shell
 npm install --save gatsby-plugin-react-helmet react-helmet
 ```
 
-2. Add the plugin to the `plugins` array in your `gatsby-config.js` file.
+2. プラグインを `gatsby-config.js` ファイルの `plugins` 配列に追加します。
 
 ```javascript:title=gatsby-config.js
 {
@@ -26,7 +26,7 @@ npm install --save gatsby-plugin-react-helmet react-helmet
 }
 ```
 
-3. Use `React Helmet` in your pages:
+3. ページ内に `React Helmet` を追加します。
 
 ```jsx
 import React from "react"
@@ -49,6 +49,6 @@ class Application extends React.Component {
 }
 ```
 
-> 💡 The above example is from the [React Helmet docs](https://github.com/nfl/react-helmet#example). Check those out for more!
+> 💡 上の例は [React Helmet ドキュメント](https://github.com/nfl/react-helmet#example) からのものです。詳細をご覧ください！
 
-You may also be interested in checking out the doc on [adding an SEO component](/docs/add-seo-component/).
+また、[SEO コンポーネントを追加](/docs/add-seo-component/) も参考になるでしょう。


### PR DESCRIPTION
## 概要

`docs/add-page-metadata` を翻訳しました。

#103 と文章が一致している箇所があったので、そちらと合わせるようにしています。

MDNへのリンクがあり #103 では英語にリンクしていました。 日本語も存在していたのでこちらのコミットではURLを変えています。
内容も翻訳されているので、日本語版でも問題ないと思いますがどうでしょうか？

レビューよろしくお願いします:bow:

参考: https://github.com/gatsbyjs/gatsby-ja/pull/103/files#diff-d3b8f5cef608d861ead080f61d0b1a2dR163

## チェックリスト

- [x] [翻訳スタイルガイド](https://github.com/gatsbyjs/gatsby-ja/blob/master/style-guide.md) に目を通しました。
- [x] [Translation Guide](https://www.gatsbyjs.org/contributing/gatsby-docs-translation-guide/#contributing-to-a-translation) に目を通しました。
- [x] `textlint` を使って校正を行いました。
- [x] 文章全体を最初から読み直して不自然な箇所が無いことを確認しました。
- [x] `Allow edits from maintainers` にチェックを入れました。

> しばらく待ってもレビューが終わらなかったり、必要なレビュー数に足りない状態が続いた場合は、[こちら](https://github.com/gatsbyjs/gatsby-ja/issues/1)からメンテナーを探して、@を付けてメンションを飛ばしてください。

## 補足

<!-- 必要であればこちらに補足を書いてください -->

<!-- ここから下は消さないで！ -->

Ref: #1
