### PR TITLE
fix: lint script glob pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "pretty-quick && textlint --cache $(git diff master --name-only) --fix",
     "format:full": "pretty-quick && textlint --cache README.md docs/**/*.md --fix",
     "lint": "textlint --cache $(git diff master --name-only) -f pretty-error",
-    "lint:full": "textlint --cache README.md 'docs/**/*.md' -f pretty-error"
+    "lint:full": "textlint --cache README.md \"docs/**/*.md\" -f pretty-error"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "pretty-quick && textlint --cache $(git diff master --name-only) --fix",
     "format:full": "pretty-quick && textlint --cache README.md docs/**/*.md --fix",
     "lint": "textlint --cache $(git diff master --name-only) -f pretty-error",
-    "lint:full": "textlint --cache README.md docs/**/*.md -f pretty-error"
+    "lint:full": "textlint --cache README.md 'docs/**/*.md' -f pretty-error"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
## 概要
翻訳PRではありません。
`lint:full`コマンドの対象ファイルのglob引数の設定にミスがあるので修正するPRです。

glob形式で引数を渡す場合はクオートで囲う必要があります。これはtextlintのドキュメントにも記載されています。
https://github.com/textlint/textlint#cli
> When running texlint, you can target files to lint using the glob patterns. Make sure that you enclose any glob parameter you pass in quotes.

<!-- 必要であればこちらに補足を書いてください -->

<!-- ここから下は消さないで！ -->

Ref: #1
