### PR TITLE
translate Docs/mdx/markdown syntax

### DIFF
--- a/docs/docs/mdx/markdown-syntax.md
+++ b/docs/docs/mdx/markdown-syntax.md
@@ -4,7 +4,7 @@ title: Markdown 構文
 
 Markdown は Gatsby でウェブサイトにページやポストを書くための標準的な方法です。この便利なガイドは Markdown 構文とフォーマットについての知識を解説します！
 
-## 見出し s
+## 見出し
 
 ```markdown
 # 見出し 1

--- a/docs/docs/mdx/markdown-syntax.md
+++ b/docs/docs/mdx/markdown-syntax.md
@@ -36,8 +36,8 @@ Markdown は Gatsby でウェブサイトにページやポストを書くため
 
 - それぞれの見出し行は等価となる HTML に変換されます
   - 例：`# 見出し 1` は `<h1>見出し 1</h1>` に変換されます
-- それぞれの見出しレベルの正しい使い方については次の資料を参照してください。
-  [accessibility guidelines](https://www.w3.org/WAI/tutorials/page-structure/headings/) by the World Wide Web Consortium (W3C)
+- それぞれの見出しレベルの正しい使い方については W3C(the World Wide Web Consortium) の [accessibility guidelines](https://www.w3.org/WAI/tutorials/page-structure/headings/) を参照してください。
+
   _ヒント: [Gatsby のドキュメント](/contributing/docs-contributions#headings) によると、H1 は Markdown の Frontmatter における `title` 要素をレンダリングする際、すでに使用されています。そのため、Markdown 本文に見出しを記載する際には H2 タグ(つまり `##` )から始めてください。_
 
 ## テキストの強調
@@ -121,7 +121,7 @@ HTML では下記のように表現されます
 
 ### 代替テキストのないイメージ
 
-この表記方法は、装飾または反復的な画像に適しています。（参考： [decorative or repetitive images](https://www.w3.org/WAI/tutorials/images/decision-tree/)）
+この表記方法は、装飾または反復的な画像に適しています。（参考： [decorative or repetitive images](https://www.w3.org/WAI/tutorials/images/decision-tree/) ）
 
 ```markdown
 ![](path-to-image)
@@ -175,7 +175,7 @@ HTML では下記のように表現されます
 ## Frontmatter
 
 - Markdown ファイルのメタデータを記載します
-- Variables that can later be injected into your components
+- これらは変数としてコンポーネント上で利用できます
 - 必須要件
   - ファイルの最初に記載すること
   - 正しい YAML 構文であること

--- a/docs/docs/mdx/markdown-syntax.md
+++ b/docs/docs/mdx/markdown-syntax.md
@@ -20,7 +20,7 @@ Markdown は Gatsby でウェブサイトにページやポストを書くため
 ###### 見出し 6
 ```
 
-Here's how those tags render in HTML:
+上記タグは HTML 上では以下のように表示されます。
 
 # 見出し 1
 

--- a/docs/docs/mdx/markdown-syntax.md
+++ b/docs/docs/mdx/markdown-syntax.md
@@ -191,7 +191,7 @@ HTML では下記のように表現されます
 
 ```mdx
 ---
-description: frontmatterのdescription例
+description: frontmatter の description 例
 ---
 
 import { Chart } from "../components/chart"

--- a/docs/docs/mdx/markdown-syntax.md
+++ b/docs/docs/mdx/markdown-syntax.md
@@ -76,13 +76,13 @@ Markdown は Gatsby でウェブサイトにページやポストを書くため
 HTML では下記のように表現されます。
 
 - Gatsby
-  - docs
+  - ドキュメント
 
 * Gatsby
-  - docs
+  - ドキュメント
 
 - Gatsby
-  - docs
+  - ドキュメント
 
 ### 番号付き箇条書き
 

--- a/docs/docs/mdx/markdown-syntax.md
+++ b/docs/docs/mdx/markdown-syntax.md
@@ -35,7 +35,7 @@ Markdown は Gatsby でウェブサイトにページやポストを書くため
 ###### 見出し 6
 
 - それぞれの見出し行は等価となる HTML に変換されます
-  - i.e. `# 見出し 1` は `<h1>見出し 1</h1>` に変換されます
+  - 例：`# 見出し 1` は `<h1>見出し 1</h1>` に変換されます
 - それぞれの見出しレベルの正しい使い方については次の資料を参照してください。
   [accessibility guidelines](https://www.w3.org/WAI/tutorials/page-structure/headings/) by the World Wide Web Consortium (W3C)
   _ヒント: [Gatsby のドキュメント](/contributing/docs-contributions#headings) によると、H1 は Markdown の Frontmatter における `title` 要素をレンダリングする際、すでに使用されています。そのため、Markdown 本文に見出しを記載する際には H2 タグ(つまり `##` )から始めてください。_

--- a/docs/docs/mdx/markdown-syntax.md
+++ b/docs/docs/mdx/markdown-syntax.md
@@ -38,7 +38,7 @@ Here's how those tags render in HTML:
   - i.e. `# 見出し 1` は `<h1>見出し 1</h1>` に変換されます
 - それぞれの見出しレベルの正しい使い方については次の資料を参照してください。
   [accessibility guidelines](https://www.w3.org/WAI/tutorials/page-structure/headings/) by the World Wide Web Consortium (W3C)
-  _Note: [Gatsby のドキュメント](/contributing/docs-contributions#headings) によると、H1 は Markdown の Frontmatter における `title` 要素をレンダリングする際、すでに使用されています。そのため、Markdown 本文に見出しを記載する際には H2 タグ(つまり `##` )から始めてください。_
+  _ヒント: [Gatsby のドキュメント](/contributing/docs-contributions#headings) によると、H1 は Markdown の Frontmatter における `title` 要素をレンダリングする際、すでに使用されています。そのため、Markdown 本文に見出しを記載する際には H2 タグ(つまり `##` )から始めてください。_
 
 ## テキストの強調
 

--- a/docs/docs/mdx/markdown-syntax.md
+++ b/docs/docs/mdx/markdown-syntax.md
@@ -1,79 +1,79 @@
 ---
-title: Markdown Syntax
+title: Markdown 構文
 ---
 
-Markdown is a very common way to write content in Gatsby posts and pages. This guide contains tips for Markdown syntax and formatting that might come in handy!
+Markdown は Gatsby でウェブサイトにページやポストを書くための標準的な方法です。この便利なガイドは Markdown 構文とフォーマットについての知識を解説します！
 
-## Headings
+## 見出し s
 
 ```markdown
-# heading 1
+# 見出し 1
 
-## heading 2
+## 見出し 2
 
-### heading 3
+### 見出し 3
 
-#### heading 4
+#### 見出し 4
 
-##### heading 5
+##### 見出し 5
 
-###### heading 6
+###### 見出し 6
 ```
 
 Here's how those tags render in HTML:
 
-# heading 1
+# 見出し 1
 
-## heading 2
+## 見出し 2
 
-### heading 3
+### 見出し 3
 
-#### heading 4
+#### 見出し 4
 
-##### heading 5
+##### 見出し 5
 
-###### heading 6
+###### 見出し 6
 
-- each heading gets converted to their HTML equivalent
-  - i.e. `# heading 1` is `<h1>heading 1</h1>`
-- Correct usage of each heading should follow the
-  [accessibility guidelines](https://www.w3.org/WAI/tutorials/page-structure/headings/) set by the World Wide Web Consortium (W3C)
-  _Note: in the [Gatsby docs](/contributing/docs-contributions#headings), h1s are already included from `title` entries in frontmatter metadata, and contributions in Markdown should begin with h2._
+- それぞれの見出し行は等価となる HTML に変換されます
+  - i.e. `# 見出し 1` は `<h1>見出し 1</h1>` に変換されます
+- それぞれの見出しレベルの正しい使い方については次の資料を参照してください。
+  [accessibility guidelines](https://www.w3.org/WAI/tutorials/page-structure/headings/) by the World Wide Web Consortium (W3C)
+  _Note: [Gatsby のドキュメント](/contributing/docs-contributions#headings) によると、H1 は Markdown の Frontmatter における `title` 要素をレンダリングする際、すでに使用されています。そのため、Markdown 本文に見出しを記載する際には H2 タグ(つまり `##` )から始めてください。_
 
-## Emphasized text
+## テキストの強調
 
-- Italic
-  - one asterisk or one underscore
-    - `*italic*` or `_italic_`
-    - _italic!_
-- Bold
-  - two asterisks or two underscores
-    - `**bold**` or `__bold__`
-    - **bold!**
-- Italic and Bold
+- 斜体（イタリック）
+  - 1 文字のアスタリスクか、アンダースコア
+    - `*斜体*` or `_斜体_`
+    - _斜体_
+- 太字（ボールド）
+  - 二文字のアスタリスクか、アンダースコア
+    - `**太字**` or `__太字__`
+    - **太字**
+- 斜体かつ太字
 
-  - three asterisks or three underscore
-    - `***italic and bold***` or `___italic and bold___`
-    - **_italic and bold!!_**
+  - 三文字のアスタリスクか、アンダースコア
+    - `***斜体かつ太字***` or `___斜体かつ太字___`
+    - **_斜体かつ太字_**
 
-## Lists
+## 箇条書き
 
-### Unordered
+### 番号なし箇条書き
 
-- can use `*`, `-`, or `+` for each list item
+- `*`, `-`, もしくは `+` をそれぞれの箇条書き要素の頭に付加しましょう。
 
 <!-- prettier-ignore-start -->
 ```markdown
 * Gatsby
-  * docs
+  * ドキュメント
 - Gatsby
-  - docs
+  - ドキュメント
 + Gatsby
-  + docs
+  + ドキュメント
 ```
 <!-- prettier-ignore-end -->
 
-How unordered lists are rendered in HTML:
+HTML では下記のように表現されます。
 
 - Gatsby
   - docs
@@ -84,126 +84,126 @@ How unordered lists are rendered in HTML:
 - Gatsby
   - docs
 
-### Ordered
+### 番号付き箇条書き
 
-- number and period for each list item
-- using `1.` for each item can automatically increment depending on the content
+- 数字とピリオドをそれぞれの箇条書き要素の頭に付加しましょう
+- `1.` を全てのアイテムの頭に付加すれば、番号は自動的に増加します
 
 ```markdown
-1. One
-1. Two
-1. Three
+1. 壱
+1. 弐
+1. 参
 ```
 
-1. One
-1. Two
-1. Three
+1. 壱
+1. 弐
+1. 参
 
-## Links and images
+## リンクと画像
 
-### Link
+### リンク
 
-Links in Markdown use this format. URLs can be relative or remote:
+リンクは Markdown において下記のように表記します。URL は絶対パス・相対パスどちらでも構いません。
 
 ```markdown
 [Text](url)
 ```
 
-Example of a link rendering in HTML:
+HTML では下記のように表現されます
 
 [Gatsby site](https://www.gatsbyjs.org/)
 
-### Image with alt text
+### イメージと代替テキスト
 
 ```markdown
 ![alt text](path-to-image)
 ```
 
-### Image without alt text
+### 代替テキストのないイメージ
 
-This pattern is appropriate for [decorative or repetitive images](https://www.w3.org/WAI/tutorials/images/decision-tree/):
+この表記方法は、装飾または反復的な画像に適しています。（参考： [decorative or repetitive images](https://www.w3.org/WAI/tutorials/images/decision-tree/)）
 
 ```markdown
 ![](path-to-image)
 ```
 
-## Blockquote
+## 引用ブロック
 
-- Use `>` to declare a blockquote
-- Adding multiple `>` with create nested blockquotes
-- It is recommended to place `>` before each line
-- You can use other Markdown syntax inside blockquotes
+- `>` を引用する行頭に付与します
+- 複数の `>` を使うことでネストされた引用を表現できます
+- `>` を引用全ての行頭に使うことを推奨します
+- 引用ブロックの中でも他の Markdown 構文は有効です
 
 ```markdown
-> blockquote
+> 引用文前半
 >
-> > nested blockquote
+> > ネストされた引用
 >
-> > **I'm bold!**
+> > **ここは太字！**
 >
-> more quotes
+> 引用文後半
 ```
 
-> Blockquote
+> 引用文前半
 >
-> > nested blockquote
+> > ネストされた引用
 >
-> > **I'm bold!**
+> > **ここは太字！**
 >
-> more quotes
+> 引用文後半
 
-## Code comments
+## コードコメント
 
-### Inline
+### 行内コード
 
-- Enclose the text in backticks \`code\`
-- Inline `code` looks like this sentence
+- コード部分をバッククオートで囲みます \`code\`
+- このように表示されます `code`
 
-### Code blocks
+### コードブロック
 
-- Indent a block by four spaces
+- コード部分を全てスペース 4 つでインデントします
 
 ## MD vs MDX
 
-- MDX is a superset of Markdown. It allows you to write JSX inside markdown. This includes importing and rendering React components!
+- MDX は Markdown の上位互換です。 JSX 構文を Markdown 内に記載することができます。つまり React コンポーネントを内部に記載できます！
 
-## Processing Markdown and MDX in Gatsby:
+## Gatsby における Markdown と MDX の処理
 
-- In order to process and use Markdown or MDX in Gatsby, you can use the [gatsby-source-filesystem](/docs/sourcing-from-the-filesystem) plugin
-- You can check out the package [README](/packages/gatsby-source-filesystem) for more information on how it works!
+- Gatsby で Markdown または MDX を使うためには [gatsby-source-filesystem](/docs/sourcing-from-the-filesystem) プラグインを利用しましょう
+- プラグインの [README](/packages/gatsby-source-filesystem) により詳しい動作説明が記載されています
 
 ## Frontmatter
 
-- Metadata for your Markdown
+- Markdown ファイルのメタデータを記載します
 - Variables that can later be injected into your components
-- Must be:
-  - At the top of the file
-  - Valid YAML
-  - Between triple dashed lines
+- 必須要件
+  - ファイルの最初に記載すること
+  - 正しい YAML 構文であること
+  - 3 つのハイフンで囲むこと
   ```
   ---
-  title: My Frontmatter Title
+  title: Frontmatterで定義したタイトル
   example_boolean: true
   ---
   ```
 
-## Frontmatter + MDX example
+## Frontmatter + MDX の例
 
 ```mdx
 ---
-description: A simple example of a description in frontmatter
+description: frontmatterのdescription例
 ---
 
 import { Chart } from "../components/chart"
 
-# Here’s a chart
+# チャート
 
-The chart is rendered inside our MDX document.
+Chart コンポーネントを MDX 内にレンダリングすることができます
 
 <Chart description={description} />
 ```
 
-## Helpful resources
+## 参考情報
 
 - https://daringfireball.net/projects/markdown/syntax
 - https://www.markdownguide.org/basic-syntax


### PR DESCRIPTION
## 概要

Translate Docs/mdx/markdown-syntax

## チェックリスト

- [x] [翻訳スタイルガイド](https://github.com/gatsbyjs/gatsby-ja/blob/master/style-guide.md) に目を通しました。
- [x] [Translation Guide](https://www.gatsbyjs.org/contributing/gatsby-docs-translation-guide/#contributing-to-a-translation) に目を通しました。
- [x] `textlint` を使って校正を行いました。
- [x] 文章全体を最初から読み直して不自然な箇所が無いことを確認しました。
- [x] `Allow edits from maintainers` にチェックを入れました。

> しばらく待ってもレビューが終わらなかったり、必要なレビュー数に足りない状態が続いた場合は、[こちら](https://github.com/gatsbyjs/gatsby-ja/issues/1)からメンテナーを探して、@を付けてメンションを飛ばしてください。

## 補足

- コードブロック内のMarkdownに書かれているタイトルやコンテンツについて、構文解説のわかりやすさを重視し日本語訳を行いました。
- 「Frontmatter」を和訳するかどうか悩みましたが、GraphQLクエリで`frontmatter`と書かなければならないため、コードの一部と考えて英単語のままとさせてもらいました。

<!-- ここから下は消さないで！ -->

Ref: #1
