### PR TITLE
Translate docs/docs/actions

### DIFF
--- a/docs/docs/actions.md
+++ b/docs/docs/actions.md
@@ -7,8 +7,7 @@ jsdoc:
 contentsHeading: Functions
 ---
 
-Gatsby は [Redux](http://redux.js.org) を内部的に使用して状態を管理しています。
-あなたのサイトで Gatsby API を実装するとアクションのコレクション（Redux の [bindActionCreators](https://redux.js.org/api/bindactioncreators/) でバインドされるアクションと同等）が渡され、状態管理に使用できます。
+Gatsby は [Redux](http://redux.js.org) を内部的に使用して状態を管理しています。あなたのサイトで Gatsby API を実装するとアクションのコレクション（Redux の [bindActionCreators](https://redux.js.org/api/bindactioncreators/) でバインドされるアクションと同等）が渡され、状態管理に使用できます。
 
 `actions` のオブジェクトに含まれる各関数は、ES6 のオブジェクトの分割代入で個別に抽出できます。
 

--- a/docs/docs/actions.md
+++ b/docs/docs/actions.md
@@ -8,7 +8,7 @@ contentsHeading: Functions
 ---
 
 Gatsby は [Redux](http://redux.js.org) を内部的に使用して状態を管理しています。
-あなたのサイトで Gatsby API を実装するとアクションのコレクション（Redux の [bindActionCreators](https://redux.js.org/api/bindactioncreators/) てバインドされるアクションと同等）が渡され、状態管理に使用できます。
+あなたのサイトで Gatsby API を実装するとアクションのコレクション（Redux の [bindActionCreators](https://redux.js.org/api/bindactioncreators/) でバインドされるアクションと同等）が渡され、状態管理に使用できます。
 
 `actions` のオブジェクトに含まれる各関数は、ES6 のオブジェクトの分割代入で個別に抽出できます。
 

--- a/docs/docs/actions.md
+++ b/docs/docs/actions.md
@@ -1,18 +1,19 @@
 ---
-title: Actions
-description: Documentation on actions and how they help you manipulate state within Gatsby
+title: アクション
+description: Gatsbyの状態管理に役立つアクションのドキュメント
 jsdoc:
   - "gatsby/src/redux/actions/public.js"
   - "gatsby/src/redux/actions/restricted.js"
 contentsHeading: Functions
 ---
 
-Gatsby uses [Redux](http://redux.js.org) internally to manage state. When you implement a Gatsby API, you are passed a collection of actions (equivalent to actions bound with [bindActionCreators](https://redux.js.org/api/bindactioncreators/) in Redux) which you can use to manipulate state on your site.
+Gatsby は [Redux](http://redux.js.org) を内部的に使用して状態を管理しています。
+あなたのサイトで Gatsby API を実装するとアクションのコレクション（Redux の [bindActionCreators](https://redux.js.org/api/bindactioncreators/) てバインドされるアクションと同等）が渡され、状態管理に使用できます。
 
-The object `actions` contains the functions and these can be individually extracted by using ES6 object destructuring.
+`actions` のオブジェクトに含まれる各関数は、ES6 のオブジェクトの分割代入で個別に抽出できます。
 
 ```javascript
-// For function createNodeField
+// createNodeField 関数の場合
 exports.onCreateNode = ({ node, getNode, actions }) => {
   const { createNodeField } = actions
 }


### PR DESCRIPTION
## 概要

`docs/docs/actions` を翻訳しました。よろしくお願いします。

## チェックリスト

- [x] [翻訳スタイルガイド](https://github.com/gatsbyjs/gatsby-ja/blob/master/style-guide.md) に目を通しました。
- [x] [Translation Guide](https://www.gatsbyjs.org/contributing/gatsby-docs-translation-guide/#contributing-to-a-translation) に目を通しました。
- [x] `textlint` を使って校正を行いました。
- [x] 文章全体を最初から読み直して不自然な箇所が無いことを確認しました。
- [x] `Allow edits from maintainers` にチェックを入れました。

> しばらく待ってもレビューが終わらなかったり、必要なレビュー数に足りない状態が続いた場合は、[こちら](https://github.com/gatsbyjs/gatsby-ja/issues/1)からメンテナーを探して、@を付けてメンションを飛ばしてください。

## 補足

<!-- 必要であればこちらに補足を書いてください -->

* `Actions` をそのまま `Actions` とするか迷ったのですが、Vuexのドキュメントではアクションと和訳されていたのでそちらに習って `アクション` としました。

<!-- ここから下は消さないで！ -->

Ref: #1
