### PR TITLE
Translate Docs/mdx/customizing-components

### DIFF
--- a/docs/docs/mdx/customizing-components.md
+++ b/docs/docs/mdx/customizing-components.md
@@ -2,8 +2,7 @@
 title: コンポーネントをカスタマイズする
 ---
 
-MDX を使えば、Markdown でレンダリングできる全ての HTML 要素をカスタマイズした実装に置き換えることが可能です。
-これによって、デザインシステムで定義されたコンポーネントを利用できるようになります。
+MDX を使えば、Markdown でレンダリングできる全ての HTML 要素をカスタマイズした実装に置き換えることが可能です。これによって、デザインシステムで定義されたコンポーネントを利用できるようになります。
 
 ```jsx:title=src/components/layout.js
 import { MDXProvider } from "@mdx-js/react"
@@ -60,8 +59,7 @@ export default function Layout({ children }) {
 
 ## これはどうやって実現されているのか？
 
-MDXProvider で変換されたコンポーネントは、Markdown が生成する HTML 要素をレンダリングする目的で使用されます。
-この過程では、[React's Context API](https://reactjs.org/docs/context.html)を用いています。
+MDXProvider で変換されたコンポーネントは、Markdown が生成する HTML 要素をレンダリングする目的で使用されます。この過程では、[React's Context API](https://reactjs.org/docs/context.html)を用いています。
 
 ## 関連ドキュメント
 

--- a/docs/docs/mdx/customizing-components.md
+++ b/docs/docs/mdx/customizing-components.md
@@ -27,6 +27,8 @@ export default function Layout({ children }) {
 }
 ```
 
+**Note**: MDX を書くときに、グローバルにアクセスできる独自のコンポーネントを `MDXProvider` に定義することもできます。このパターンに関しては、[MDX にコンポーネントを import して使う方法](/docs/mdx/importing-and-using-components/#make-components-available-globally-as-shortcodes) を参照してください。
+
 以下の表は、MDXProvider を用いてカスタマイズできるコンポーネントの一覧です。
 
 | Tag             | Name                                                                 | Syntax                                              |

--- a/docs/docs/mdx/customizing-components.md
+++ b/docs/docs/mdx/customizing-components.md
@@ -2,8 +2,8 @@
 title: コンポーネントをカスタマイズする
 ---
 
-MDX を使えば，Markdown でレンダリングできる全ての HTML 要素をカスタマイズした実装に置き換えることが可能です。
-これによって，デザインシステムで定義されたコンポーネントを利用できるようになります。
+MDX を使えば、Markdown でレンダリングできる全ての HTML 要素をカスタマイズした実装に置き換えることが可能です。
+これによって、デザインシステムで定義されたコンポーネントを利用できるようになります。
 
 ```jsx:title=src/components/layout.js
 import { MDXProvider } from "@mdx-js/react"
@@ -13,11 +13,11 @@ export default function Layout({ children }) {
   return (
     <MDXProvider
       components={{
-        // HTML 要素のタグを，React コンポーネントにマッピングする
+        // HTML 要素のタグを、React コンポーネントにマッピングする
         h1: DesignSystem.H1,
         h2: DesignSystem.H2,
         h3: DesignSystem.H3,
-        // あるいは，インラインでもコンポーネントを定義できます
+        // あるいは、インラインでもコンポーネントを定義できます
         p: props => <p {...props} style={{ color: "rebeccapurple" }} />,
       }}
     >
@@ -27,7 +27,7 @@ export default function Layout({ children }) {
 }
 ```
 
-以下の表は，MDXProvider を用いてカスタマイズできるコンポーネントの一覧です。
+以下の表は、MDXProvider を用いてカスタマイズできるコンポーネントの一覧です。
 
 | Tag             | Name                                                                 | Syntax                                              |
 | --------------- | -------------------------------------------------------------------- | --------------------------------------------------- |
@@ -58,8 +58,8 @@ export default function Layout({ children }) {
 
 ## これはどうやって実現されているのか？
 
-MDXProvider で変換されたコンポーネントは，Markdown が生成する HTML 要素をレンダリングする目的で使用されます。
-この過程では，[React's Context API](https://reactjs.org/docs/context.html)を用いています。
+MDXProvider で変換されたコンポーネントは、Markdown が生成する HTML 要素をレンダリングする目的で使用されます。
+この過程では、[React's Context API](https://reactjs.org/docs/context.html)を用いています。
 
 ## 関連ドキュメント
 

--- a/docs/docs/mdx/customizing-components.md
+++ b/docs/docs/mdx/customizing-components.md
@@ -1,10 +1,9 @@
 ---
-title: Customizing Markdown Components
+title: コンポーネントをカスタマイズする
 ---
 
-Using MDX, you can replace every HTML element that Markdown renders with a
-custom implementation. This allows you to use a set of design system components
-when rendering.
+MDX を使えば，Markdown でレンダリングできる全ての HTML 要素をカスタマイズした実装に置き換えることが可能です。
+これによって，デザインシステムで定義されたコンポーネントを利用できるようになります。
 
 ```jsx:title=src/components/layout.js
 import { MDXProvider } from "@mdx-js/react"
@@ -14,11 +13,11 @@ export default function Layout({ children }) {
   return (
     <MDXProvider
       components={{
-        // Map HTML element tag to React component
+        // HTML 要素のタグを，React コンポーネントにマッピングする
         h1: DesignSystem.H1,
         h2: DesignSystem.H2,
         h3: DesignSystem.H3,
-        // Or define component inline
+        // あるいは，インラインでもコンポーネントを定義できます
         p: props => <p {...props} style={{ color: "rebeccapurple" }} />,
       }}
     >
@@ -28,9 +27,7 @@ export default function Layout({ children }) {
 }
 ```
 
-**Note**: you can also provide your own custom components to the `MDXProvider` that make them globally available while writing MDX. You can find more details about this pattern in the [Importing and Using Components in MDX guide](/docs/mdx/importing-and-using-components/#make-components-available-globally-as-shortcodes).
-
-The following components can be customized with the MDXProvider:
+以下の表は，MDXProvider を用いてカスタマイズできるコンポーネントの一覧です。
 
 | Tag             | Name                                                                 | Syntax                                              |
 | --------------- | -------------------------------------------------------------------- | --------------------------------------------------- |
@@ -59,12 +56,11 @@ The following components can be customized with the MDXProvider:
 | `a`             | [Link](https://github.com/syntax-tree/mdast#link)                    | `<https://mdxjs.com>` or `[MDX](https://mdxjs.com)` |
 | `img`           | [Image](https://github.com/syntax-tree/mdast#image)                  | `![alt](https://mdx-logo.now.sh)`                   |
 
-## How does this work?
+## これはどうやって実現されているのか？
 
-Components passed to the MDXProvider are used to render the HTML elements
-that Markdown creates. It uses
-[React's Context API](https://reactjs.org/docs/context.html).
+MDXProvider で変換されたコンポーネントは，Markdown が生成する HTML 要素をレンダリングする目的で使用されます。
+この過程では，[React's Context API](https://reactjs.org/docs/context.html)を用いています。
 
-## Related
+## 関連ドキュメント
 
 - [MDX components](https://mdxjs.com/getting-started/)


### PR DESCRIPTION
## 概要

docs/docs/mdx/customizing-components.md の翻訳です。
レビューお願いしますm(_ _)m

## チェック一覧

- [x] [翻訳スタイルガイド](https://github.com/gatsbyjs/gatsby-ja/blob/master/style-guide.md) に目を通しました。
- [x] [Translation Guide](https://www.gatsbyjs.org/contributing/gatsby-docs-translation-guide/#contributing-to-a-translation) に目を通しました。
- [x] `textlint` を使って校正を行いました。
- [x] 文章全体を最初から読み直して不自然な箇所が無いことを確認しました。
- [x] `Allow edits from maintainers` にチェックを入れました。

> しばらく待ってもレビューが終わらなかったり、必要なレビュー数に足りない状態が続いた場合は、[こちら](https://github.com/gatsbyjs/gatsby-ja/issues/1)からメンテナーを探して、@を付けてメンションを飛ばしてください。

## 補足

翻訳前のドキュメントでは，1パラグラフを複数行に分ける書き方がなされていましたが，訳の方は1パラグラフ1行で書いています。

<!-- ここから下は消さないで！ -->

Ref: #1
