### PR TITLE
fix lint.yml for disable add-path command

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Setup reviewdog
         run: |
           mkdir -p $HOME/bin && curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b $HOME/bin
-          echo ::add-path::$HOME/bin
-          echo ::add-path::$(go env GOPATH)/bin # for Go projects
+          echo "$HOME/bin" >> $GITHUB_PATH
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH # for Go projects
 
       - name: Install dependencies
         run: yarn --frozen-lockfile


### PR DESCRIPTION
## 概要

Github Actionsのlint.ymlで利用されている `add-path` コマンドが利用できなくなったことで
失敗してしまっていたので修正しました。

## チェック一覧

- [x] `Allow edits from maintainers` にチェックを入れました。

> しばらく待ってもレビューが終わらなかったり、必要なレビュー数に足りない状態が続いた場合は、[こちら](https://github.com/gatsbyjs/gatsby-ja/issues/1)からメンテナーを探して、@を付けてメンションを飛ばしてください。

## 補足

通知
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

修正時の参考サイト
https://dev.classmethod.jp/articles/replace-deprecated-method-on-actions/

<!-- ここから下は消さないで！ -->

Ref: #335 
