### PR TITLE
docs: translate docs/customization

### DIFF
--- a/docs/docs/customization.md
+++ b/docs/docs/customization.md
@@ -1,8 +1,8 @@
 ---
-title: Custom Configuration
+title: カスタム設定
 overview: true
 ---
 
-Sometimes you may find yourself in a situation where Gatsby's default configuration just isn't quite what you need for your site. If you should find yourself in this situation, have no fear my friend, you can customize Gatsby's config for `babel` and `webpack`. You can also customize `html.js`, the React component used to generate the initial HTML file of your build. You'll also find guides on how to get custom environment variables into your website, as well how to proxy API requests in development so your API calls aren't interpreted by your server as static assets.
+Gatsby のデフォルトの設定では、サイトに必要なものとは大きく異なってくることがあるかもしれません。このような場合でも、 Gatsby の設定を `babel` や `webpack` 用にカスタマイズできるので、心配する必要はありません。また、 React コンポーネントが HTML ファイルのビルド時に使っている `html.js` もカスタマイズできます。その上、Web サイトにカスタム環境変数を取り入れる方法や、呼び出した API がサーバーによってスタティックアセットとして解釈されないように開発中の API リクエストをプロキシする方法に関するガイドもあります。
 
 <GuideList slug={props.slug} />


### PR DESCRIPTION
## 概要

I translated docs/coming-from-react-to-gatsby.md into Japanese.

## チェック一覧

- [x] [翻訳スタイルガイド](https://github.com/gatsbyjs/gatsby-ja/blob/master/style-guide.md) に目を通しました。
- [x] [Translation Guide](https://www.gatsbyjs.org/contributing/gatsby-docs-translation-guide/#contributing-to-a-translation) に目を通しました。
- [x] `textlint` を使って校正を行いました。
- [x] 文章全体を最初から読み直して不自然な箇所が無いことを確認しました。
- [x] `Allow edits from maintainers` にチェックを入れました。

> しばらく待ってもレビューが終わらなかったり、必要なレビュー数に足りない状態が続いた場合は、[こちら](https://github.com/gatsbyjs/gatsby-ja/issues/1)からメンテナーを探して、@を付けてメンションを飛ばしてください。

## 補足

<!-- 必要であればこちらに補足を書いてください -->

<!-- ここから下は消さないで！ -->

Ref: #1
